### PR TITLE
Suggesting adding the Google Play download button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Decred Mobile Wallet for android that runs on top of [dcrwallet](https://github.com/decred/dcrwallet).
 
+[![Get it on Google Play](https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png)](https://play.google.com/store/apps/details?id=com.decred.dcrandroid.mainnet&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1)
+   
 ## Requirements
 
 Android 3.0 or above.


### PR DESCRIPTION
In order to support end users who find the repo but are actually looking to install the app, I suggest adding a simple markdown link with the google badge image to click and download the app for mobile.